### PR TITLE
actions: Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_dotnet:
     runs-on: windows-latest
     if: "!contains(github.event.head_commit.message, '-noci')"
 
@@ -105,3 +105,29 @@ jobs:
         with:
           name: CinematicUnityExplorer.Editor.zip
           path: ./UnityEditorPackage/
+          
+
+  build_connector:
+    runs-on: windows-latest
+    if: "!contains(github.event.head_commit.message, '-noci')"
+
+    steps:
+      - name: Checkout latest
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Setup C/C++
+        uses: TheMrMilchmann/setup-msvc-dev@v3.0.0
+        with:
+          arch: x64
+
+      # Run build script
+      - name: Build Unity IGCS Connector
+        run: ./build_connector.ps1
+
+      - name: Upload Unity IGCS Connector
+        uses: actions/upload-artifact@v3
+        with:
+          name: UnityIGCSConnector.dll
+          path: ./Release/UnityIGCSConnector.dll

--- a/build.ps1
+++ b/build.ps1
@@ -2,9 +2,6 @@ cd UniverseLib
 .\build.ps1
 cd ..
 
-# ----------- Build UnityIGCSConnector ------------
-msbuild.exe UnityIGCSConnector/UnityIGCSConnector.sln -p:Configuration=Release
-
 # ----------- MelonLoader IL2CPP (net6) -----------
 dotnet build src/CinematicUnityExplorer.sln -c Release_ML_Cpp_net6preview
 $Path = "Release\CinematicUnityExplorer.MelonLoader.IL2CPP.net6preview"

--- a/build_connector.ps1
+++ b/build_connector.ps1
@@ -1,0 +1,3 @@
+# ----------- Build UnityIGCSConnector ------------
+msbuild.exe UnityIGCSConnector/UnityIGCSConnector.sln -p:Configuration=Release
+


### PR DESCRIPTION
Add support for C/C++ in the pipeline and upload the newer igcs connector.

It was necessary to create two different build scripts because for some reason when you install the msvc compiler in a github action everything Just Breaks.

Then we create two different jobs to make sure they're independent instances of containers that don't mess with other's environments.