### PR TITLE
IGCSDOF: Go back to the original position after an EndSession.

### DIFF
--- a/src/Cinematic/UnityIGCSConnector.cs
+++ b/src/Cinematic/UnityIGCSConnector.cs
@@ -42,16 +42,12 @@ namespace CinematicUnityExplorer.Cinematic
         private readonly Queue<StepCommand> commands = new();
 
         private IntPtr CameraStatus = IntPtr.Zero;
-        // In order to avoid allocations on every Update call, we create this buffer to allocate once
-        // and copy from here the CameraStatus (because Marshal.Copy requires a buffer, urgh).
-        private readonly byte[] CameraStatusBuffer = new byte[] { 0x0 };
 
         public void UpdateFreecamStatus(bool enabled)
         {
             if (CameraStatus == IntPtr.Zero) return;
-
-            CameraStatusBuffer[0] = enabled ? (byte)0x1 : (byte)0x0;
-            Marshal.Copy(CameraStatusBuffer, 0, CameraStatus, 1);
+            
+            Marshal.WriteByte(CameraStatus, enabled ? (byte)0x1 : (byte)0x0);
         }
 
         public void ExecuteCameraCommand(Camera cam)

--- a/src/Cinematic/UnityIGCSConnector.cs
+++ b/src/Cinematic/UnityIGCSConnector.cs
@@ -56,6 +56,10 @@ namespace CinematicUnityExplorer.Cinematic
         public void ExecuteCameraCommand(Camera cam)
         {
             var transform = cam.transform;
+
+            // Check whether we should go back to the original position despite being active or not
+            this.ShouldMoveToOriginalPosition(transform);
+
             if (!_isActive || position == null)
             {
                 position = new(transform.position, transform.rotation);
@@ -91,12 +95,11 @@ namespace CinematicUnityExplorer.Cinematic
         // At the EndSession, since we have a queue system, we have to have a special check when the session ends and
         // then move the camera back to the original position, because the queue gets cleaned as soon as the session
         // ends.
-        public void ShouldMoveToOriginalPosition(Camera cam)
+        public void ShouldMoveToOriginalPosition(Transform transform)
         {
             if (!isValid) return;
             if (endSessionPosition == null) return;
 
-            var transform = cam.transform;
             transform.position = endSessionPosition.Item1;
             transform.rotation = endSessionPosition.Item2;
 

--- a/src/Cinematic/UnityIGCSConnector.cs
+++ b/src/Cinematic/UnityIGCSConnector.cs
@@ -29,6 +29,9 @@ namespace CinematicUnityExplorer.Cinematic
         // Store the initial position when a session start in IGCSDof.
         Mono.CSharp.Tuple<Vector3, Quaternion> position = null;
 
+        // When we end a session, we need to make sure to go back to the position when the session ends.
+        private Mono.CSharp.Tuple<Vector3, Quaternion> endSessionPosition = null;
+
         private readonly bool isValid = false;
         private bool _isActive = false;
         public bool IsActive => isValid && _isActive;
@@ -85,8 +88,24 @@ namespace CinematicUnityExplorer.Cinematic
             _isActive = true;
         }
 
+        // At the EndSession, since we have a queue system, we have to have a special check when the session ends and
+        // then move the camera back to the original position, because the queue gets cleaned as soon as the session
+        // ends.
+        public void ShouldMoveToOriginalPosition(Camera cam)
+        {
+            if (!isValid) return;
+            if (endSessionPosition == null) return;
+
+            var transform = cam.transform;
+            transform.position = endSessionPosition.Item1;
+            transform.rotation = endSessionPosition.Item2;
+
+            endSessionPosition = null;
+        }
+
         private void EndSession()
         {
+            endSessionPosition = position;
             position = null;
             _isActive = false;
 

--- a/src/UI/Panels/FreeCamPanel.cs
+++ b/src/UI/Panels/FreeCamPanel.cs
@@ -685,7 +685,7 @@ namespace UnityExplorer.UI.Panels
                     FreeCamPanel.EndFreecam();
                     return;
                 }
-
+                FreeCamPanel.connector.ShouldMoveToOriginalPosition(FreeCamPanel.ourCamera);
                 Transform transform = FreeCamPanel.ourCamera.transform;
 
                 if (!FreeCamPanel.blockFreecamMovementToggle.isOn && !FreeCamPanel.cameraPathMover.playingPath && FreeCamPanel.connector?.IsActive != true) {

--- a/src/UI/Panels/FreeCamPanel.cs
+++ b/src/UI/Panels/FreeCamPanel.cs
@@ -685,7 +685,6 @@ namespace UnityExplorer.UI.Panels
                     FreeCamPanel.EndFreecam();
                     return;
                 }
-                FreeCamPanel.connector.ShouldMoveToOriginalPosition(FreeCamPanel.ourCamera);
                 Transform transform = FreeCamPanel.ourCamera.transform;
 
                 if (!FreeCamPanel.blockFreecamMovementToggle.isOn && !FreeCamPanel.cameraPathMover.playingPath && FreeCamPanel.connector?.IsActive != true) {


### PR DESCRIPTION
It was in fact, an issue, when you end a session, the camera doesn't go back to the original position. This makes sense since the queue gets cleaned and it might be the case the camera just stands where the focus plane is.

Since we use a queue system, the easier way was just to add a new variable that holds the position when the endsession is called and then clean it up once we go back to the original position.

Not related with the commit but also a change that removes an unnecessary buffer... let me know if you prefer to move that out.

It's really easy to replicate the issue:

1) Start a session
2) Choose a very big `Max. bokeh size`
3) Hold your finger to a relevant part of the composition (an eye, for example)
4) Start session
5) Cancel session
6) surprise surprise, the finger doesn't point where it originally did.