### PR TITLE
Added advance setting to select target camera

### DIFF
--- a/src/Config/ConfigManager.cs
+++ b/src/Config/ConfigManager.cs
@@ -64,7 +64,7 @@ namespace UnityExplorer.Config
 
         public static ConfigElement<FreeCamPanel.FreeCameraType> Default_Freecam;
         public static ConfigElement<string> Custom_Components_To_Disable;
-        public static ConfigElement<int> Preferred_Target_Camera;
+        public static ConfigElement<string> Preferred_Target_Camera;
 
         // internal configs
         internal static InternalConfigHandler InternalHandler { get; private set; }
@@ -321,7 +321,7 @@ namespace UnityExplorer.Config
             Preferred_Target_Camera = new("Preferred Target Camera",
                 "The camera that will be targeted by the freecam methods.\n" +
                 "Only used when Advanced Freecam Selection is enabled.",
-                -1);
+                "\\");
         }
     }
 }

--- a/src/Config/ConfigManager.cs
+++ b/src/Config/ConfigManager.cs
@@ -33,6 +33,7 @@ namespace UnityExplorer.Config
         public static ConfigElement<bool> Auto_Scale_UI;
         public static ConfigElement<bool> Reset_Camera_Transform;
         public static ConfigElement<float> Arrow_Size;
+        public static ConfigElement<bool> Advanced_Freecam_Selection;
 
         public static ConfigElement<KeyCode> Pause;
         public static ConfigElement<KeyCode> Frameskip;
@@ -63,6 +64,7 @@ namespace UnityExplorer.Config
 
         public static ConfigElement<FreeCamPanel.FreeCameraType> Default_Freecam;
         public static ConfigElement<string> Custom_Components_To_Disable;
+        public static ConfigElement<int> Preferred_Target_Camera;
 
         // internal configs
         internal static InternalConfigHandler InternalHandler { get; private set; }
@@ -198,6 +200,10 @@ namespace UnityExplorer.Config
                 "Cam Paths nodes and Lights Manager lights visualizers' arrow size (must be positive) (needs visualizer toggled to reflect changes).",
                 1f);
 
+            Advanced_Freecam_Selection = new("Advanced Freecam Selection",
+                "Enables certain advanced settings on the Freecam panel, in case the user can't get the freecam to work properly (requires game reset).",
+                false);
+
             Pause = new("Pause",
                 "Toggle the pause of the game.",
                 KeyCode.PageUp);
@@ -311,6 +317,11 @@ namespace UnityExplorer.Config
             Custom_Components_To_Disable = new("Custom components to disable",
                 "List of custom components to disable when enabling the freecam (gets automatically updated when editing it from the freecam panel).",
                 "");
+
+            Preferred_Target_Camera = new("Preferred Target Camera",
+                "The camera that will be targeted by the freecam methods.\n" +
+                "Only used when Advanced Freecam Selection is enabled.",
+                -1);
         }
     }
 }

--- a/src/Loader/Standalone/Editor/ExplorerEditorBehaviour.cs
+++ b/src/Loader/Standalone/Editor/ExplorerEditorBehaviour.cs
@@ -31,7 +31,9 @@ namespace UnityExplorer.Loader.Standalone
         public bool Reset_Camera_Transform;
         public FreeCamPanel.FreeCameraType Default_Freecam;
         public string Custom_Components_To_Disable;
+        public int Preferred_Target_Camera;
         public float Arrow_Size = 1f;
+        public bool Advanced_Freecam_Selection;
 
         public KeyCode Pause;
         public KeyCode Frameskip;
@@ -90,7 +92,10 @@ namespace UnityExplorer.Loader.Standalone
             ConfigManager.Reset_Camera_Transform.Value = this.Reset_Camera_Transform;
             ConfigManager.Default_Freecam.Value = this.Default_Freecam;
             ConfigManager.Custom_Components_To_Disable.Value = this.Custom_Components_To_Disable;
+            ConfigManager.Preferred_Target_Camera.Value = this.Preferred_Target_Camera;
+
             ConfigManager.Arrow_Size.Value = this.Arrow_Size;
+            ConfigManager.Advanced_Freecam_Selection.Value = this.Advanced_Freecam_Selection;
 
             ConfigManager.Pause.Value = this.Pause;
             ConfigManager.Frameskip.Value = this.Frameskip;

--- a/src/Loader/Standalone/Editor/ExplorerEditorBehaviour.cs
+++ b/src/Loader/Standalone/Editor/ExplorerEditorBehaviour.cs
@@ -31,7 +31,7 @@ namespace UnityExplorer.Loader.Standalone
         public bool Reset_Camera_Transform;
         public FreeCamPanel.FreeCameraType Default_Freecam;
         public string Custom_Components_To_Disable;
-        public int Preferred_Target_Camera;
+        public string Preferred_Target_Camera;
         public float Arrow_Size = 1f;
         public bool Advanced_Freecam_Selection;
 

--- a/src/UI/Panels/FreeCamPanel.cs
+++ b/src/UI/Panels/FreeCamPanel.cs
@@ -133,7 +133,7 @@ namespace UnityExplorer.UI.Panels
                 cameras = RuntimeHelper.FindObjectsOfTypeAll<Camera>();
             }
 
-            return cameras;
+            return cameras.Where(c => c.name != "CUE Camera").ToArray();
         }
 
         private static Camera GetTargetCamera()
@@ -144,7 +144,7 @@ namespace UnityExplorer.UI.Panels
                 return currentMain;
             }
 
-            Camera[] cameras = GetAvailableCameras().Where(c => c.name != "CUE Camera").ToArray();
+            Camera[] cameras = GetAvailableCameras();
 
             int selectedCameraTargetIndex = -1;
 
@@ -158,7 +158,7 @@ namespace UnityExplorer.UI.Panels
                     targetCameraDropdown.options.Add(new Dropdown.OptionData(cam.name));
 
                     // The user selected a target camera at some point, default to that
-                    if (i == ConfigManager.Preferred_Target_Camera.Value) {
+                    if (ConfigManager.Preferred_Target_Camera.Value == GetGameObjectPath(cam.gameObject)) {
                         selectedCameraTargetIndex = i;
                     }
                 }
@@ -419,8 +419,21 @@ namespace UnityExplorer.UI.Panels
 
         internal static void UpdateTargetCameraAction(int newCameraIndex)
         {
-            ConfigManager.Preferred_Target_Camera.Value = newCameraIndex;
+            Camera[] cameras = GetAvailableCameras();
+            Camera cam = cameras[newCameraIndex];
+            ConfigManager.Preferred_Target_Camera.Value = GetGameObjectPath(cam.gameObject);
             MaybeResetFreecam();
+        }
+
+        public static string GetGameObjectPath(GameObject obj)
+        {
+            string path = "/" + obj.name;
+            while (obj.transform.parent != null)
+            {
+                obj = obj.transform.parent.gameObject;
+                path = "/" + obj.name + path;
+            }
+            return path;
         }
 
         // Experimental feature to automatically disable cinemachine when turning on the gameplay freecam.

--- a/src/UI/Panels/FreeCamPanel.cs
+++ b/src/UI/Panels/FreeCamPanel.cs
@@ -169,16 +169,7 @@ namespace UnityExplorer.UI.Panels
                     selectedCameraTargetIndex = Array.IndexOf(cameras, Camera.main);
                 }
 
-#if STANDALONE
-                // Standalone doesn't have a reference to Dropdown.SetValueWithoutNotify
-                // Should still check this implementation
-                targetCameraDropdown.onValueChanged.RemoveListener(UpdateTargetCameraAction);
-                targetCameraDropdown.value = selectedCameraTargetIndex;
-                targetCameraDropdown.onValueChanged.AddListener(UpdateTargetCameraAction);
-#else
-                targetCameraDropdown.SetValueWithoutNotify(selectedCameraTargetIndex);
-#endif
-                
+                SetTargetDropdownValueWithoutNotify(selectedCameraTargetIndex);
                 targetCameraDropdown.captionText.text = cameras[selectedCameraTargetIndex].name;
             }
 
@@ -425,6 +416,22 @@ namespace UnityExplorer.UI.Panels
             MaybeResetFreecam();
         }
 
+        internal static void SetTargetDropdownValueWithoutNotify(int selectedCameraTargetIndex)
+        {
+            // Some build types don't have a reference to Dropdown.SetValueWithoutNotify
+            MethodInfo SetValueWithoutNotifyMethod = targetCameraDropdown.GetType().GetMethod("SetValueWithoutNotify", new[] { typeof(int) });
+            if (SetValueWithoutNotifyMethod != null)
+            {
+                SetValueWithoutNotifyMethod.Invoke(targetCameraDropdown, new object[] { selectedCameraTargetIndex });
+            }
+            else
+            {
+                targetCameraDropdown.onValueChanged.RemoveListener(UpdateTargetCameraAction);
+                targetCameraDropdown.value = selectedCameraTargetIndex;
+                targetCameraDropdown.onValueChanged.AddListener(UpdateTargetCameraAction);
+            }
+        }
+
         public static string GetGameObjectPath(GameObject obj)
         {
             string path = "/" + obj.name;
@@ -567,16 +574,7 @@ namespace UnityExplorer.UI.Panels
                         targetCameraDropdown.options.Add(new Dropdown.OptionData(cam.name));
                     }
                     if (Camera.main) {
-#if STANDALONE
-                        // Standalone doesn't have a reference to Dropdown.SetValueWithoutNotify
-                        // Should still check this implementation
-                        targetCameraDropdown.onValueChanged.RemoveListener(UpdateTargetCameraAction);
-                        targetCameraDropdown.value = Array.IndexOf(cameras, Camera.main);
-                        targetCameraDropdown.onValueChanged.AddListener(UpdateTargetCameraAction);
-#else
-                        targetCameraDropdown.SetValueWithoutNotify(Array.IndexOf(cameras, Camera.main));
-#endif
-
+                        SetTargetDropdownValueWithoutNotify(Array.IndexOf(cameras, Camera.main));
                         targetCameraDropdown.captionText.text = Camera.main.name;
                     }
                 }

--- a/src/UI/Panels/FreeCamPanel.cs
+++ b/src/UI/Panels/FreeCamPanel.cs
@@ -138,10 +138,9 @@ namespace UnityExplorer.UI.Panels
 
         private static Camera GetTargetCamera()
         {
-            Camera currentMain = Camera.main;
             if (!ConfigManager.Advanced_Freecam_Selection.Value && !targetCameraDropdown)
             {
-                return currentMain;
+                return Camera.main;
             }
 
             Camera[] cameras = GetAvailableCameras();
@@ -166,7 +165,14 @@ namespace UnityExplorer.UI.Panels
                 // If couldn't find the user selected camera default to the main camera
                 if (selectedCameraTargetIndex == -1)
                 {
-                    selectedCameraTargetIndex = Array.IndexOf(cameras, Camera.main);
+                    for (int i = 0; i < cameras.Length; i++)
+                    {
+                        if (cameras[i] == Camera.main)
+                        {
+                            selectedCameraTargetIndex = i;
+                            break;
+                        }
+                    }
                 }
 
                 SetTargetDropdownValueWithoutNotify(selectedCameraTargetIndex);
@@ -327,12 +333,6 @@ namespace UnityExplorer.UI.Panels
 
         internal static void EndFreecam()
         {
-            if (ourCamera == null)
-            {
-                ExplorerCore.LogWarning("EndFreecam called but ourCamera is null, returning.");
-                return;
-            }
-
             inFreeCamMode = false;
             connector?.UpdateFreecamStatus(false);
 
@@ -363,8 +363,8 @@ namespace UnityExplorer.UI.Panels
                     MaybeToggleOrthographic(true);
                     ToggleCustomComponents(true);
                     MethodInfo resetCullingMatrixMethod = typeof(Camera).GetMethod("ResetCullingMatrix", new Type[] {});
-
                     resetCullingMatrixMethod.Invoke(ourCamera, null);
+
                     ourCamera.ResetWorldToCameraMatrix();
                     ourCamera.ResetProjectionMatrix();
                     ourCamera = null;
@@ -565,7 +565,6 @@ namespace UnityExplorer.UI.Panels
                 UIFactory.SetLayoutElement(TargetCamLabel.gameObject, minWidth: 75, minHeight: 25);
 
                 GameObject targetCameraDropdownObj = UIFactory.CreateDropdown(CameraModeRow, "TargetCamera_Dropdown", out targetCameraDropdown, null, 14, null);
-
                 targetCameraDropdown.onValueChanged.AddListener(UpdateTargetCameraAction);
 
                 try {


### PR DESCRIPTION
Some games have their main cameras wrongly tagged or just straight up missing (e.g. [Dungeons of Hinterberg Demo](https://steamcommunity.com/app/2887710) and [PIGFACE Demo](https://store.steampowered.com/app/3746840/PIGFACE_Demo/)). Therefore, I added an optional dropdown that can be used to select the camera that you want to target with the freecam methods. This should help us add freecam support to all Unity games now.

![Dungeons_of_Hinterberg_r82qmYDS8h](https://github.com/user-attachments/assets/7701ebdc-2d43-4e24-b3bb-0ff0e926431b)

To be able to use this new dropdown you would need to go to CUE options and enable the "Advanced Freecam Selection". And then restart the game.

As a sidenote, I also refactored some of the try and catch blocks on the FreeCamBehaviour so to try each of those individually instead of failing on one and not trying the rest.

🟢 [Passing build](https://github.com/originalnicodr/CinematicUnityExplorer/actions/runs/15787899900)