### PR TITLE
Unity 6 scene.handle compatability fix.

### DIFF
--- a/src/ObjectExplorer/SceneExplorer.cs
+++ b/src/ObjectExplorer/SceneExplorer.cs
@@ -70,7 +70,7 @@ namespace UnityExplorer.ObjectExplorer
             if (SceneHandler.SelectedScene != go.scene)
             {
                 int idx;
-                if (go.scene == default || go.scene.handle == -1)
+                if (go.scene == default || go.scene.name == "DontDestroyOnLoad") //scene.handle no longer exists in Unity 6
                     idx = sceneDropdown.options.Count - 1;
                 else
                     idx = sceneDropdown.options.IndexOf(sceneToDropdownOption[go.scene]);

--- a/src/ObjectExplorer/SceneHandler.cs
+++ b/src/ObjectExplorer/SceneHandler.cs
@@ -46,10 +46,21 @@ namespace UnityExplorer.ObjectExplorer
         /// <summary>Whether or not the "DontDestroyOnLoad" scene exists in this game.</summary>
         public static bool DontDestroyExists { get; private set; }
 
+        private static bool DoesDontDestroyOnLoadExist()
+        {
+            for (int i = 0; i < SceneManager.sceneCount; i++)
+            {
+                Scene scene = SceneManager.GetSceneAt(i);
+                if (scene.name == "DontDestroyOnLoad")
+                    return true;
+            }
+            return false;
+        }
+
         internal static void Init()
         {
             // Check if the game has "DontDestroyOnLoad"
-            DontDestroyExists = Scene.GetNameInternal(-12) == "DontDestroyOnLoad";
+            DontDestroyExists = DoesDontDestroyOnLoadExist();
 
             // Try to get all scenes in the build settings. This may not work.
             try
@@ -80,8 +91,8 @@ namespace UnityExplorer.ObjectExplorer
             // Inspected scene will exist if it's DontDestroyOnLoad or HideAndDontSave
             bool inspectedExists =
                 SelectedScene.HasValue
-                && ((DontDestroyExists && SelectedScene.Value.handle == -12)
-                    || SelectedScene.Value.handle == -1);
+                && ((DontDestroyExists && SelectedScene.Value.name == "DontDestroyOnLoad")
+                || !SelectedScene.Value.IsValid());
 
             LoadedScenes.Clear();
 
@@ -98,9 +109,9 @@ namespace UnityExplorer.ObjectExplorer
                 LoadedScenes.Add(scene);
             }
 
-            if (DontDestroyExists)
-                LoadedScenes.Add(new Scene { m_Handle = -12 });
-            LoadedScenes.Add(new Scene { m_Handle = -1 });
+            //if (DontDestroyExists)
+            //    LoadedScenes.Add(new Scene { m_Handle = -12 });
+            //LoadedScenes.Add(new Scene { m_Handle = -1 });
 
             // Default to first scene if none selected or previous selection no longer exists.
             if (!inspectedExists)

--- a/src/ObjectExplorer/SearchProvider.cs
+++ b/src/ObjectExplorer/SearchProvider.cs
@@ -31,7 +31,7 @@ namespace UnityExplorer.ObjectExplorer
             return filter switch
             {
                 SceneFilter.Any => true,
-                SceneFilter.DontDestroyOnLoad => scene.handle == -12,
+                SceneFilter.DontDestroyOnLoad => scene.name == "DontDestroyOnLoad", //Scene.handle no longer exists in Unity 6
                 SceneFilter.HideAndDontSave => scene == default,
                 SceneFilter.ActivelyLoaded => scene.buildIndex != -1,
                 _ => false,

--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -129,7 +129,7 @@ namespace UnityExplorer.UI
             if (!UIRoot)
                 return;
             // If we are doing a Mouse Inspect, we don't need to update anything else.
-            if (MouseInspector.Instance?.TryUpdate() ?? false)  //instance is sometimes null for some reason?
+            if (MouseInspector.Instance.TryUpdate())
                 return;
             // Update Notification modal
             Notification.Update();

--- a/src/UI/UIManager.cs
+++ b/src/UI/UIManager.cs
@@ -128,21 +128,16 @@ namespace UnityExplorer.UI
         {
             if (!UIRoot)
                 return;
-
             // If we are doing a Mouse Inspect, we don't need to update anything else.
-            if (MouseInspector.Instance.TryUpdate())
+            if (MouseInspector.Instance?.TryUpdate() ?? false)  //instance is sometimes null for some reason?
                 return;
-
             // Update Notification modal
             Notification.Update();
-
             // Check forceUnlockMouse toggle
             if (IInputManager.GetKeyDown(ConfigManager.Force_Unlock_Toggle.Value))
                 UniverseLib.Config.ConfigManager.Force_Unlock_Mouse = !UniverseLib.Config.ConfigManager.Force_Unlock_Mouse;
-
             // update the timescale value
             timeScaleWidget.Update();
-
             // check screen dimension change
             Display display = DisplayManager.ActiveDisplay;
             if (display.renderingWidth != lastScreenWidth || display.renderingHeight != lastScreenHeight)

--- a/src/UI/Widgets/GameObjects/GameObjectInfoPanel.cs
+++ b/src/UI/Widgets/GameObjects/GameObjectInfoPanel.cs
@@ -1,4 +1,5 @@
-﻿using UnityExplorer.UI.Panels;
+﻿using UnityEngine.SceneManagement;
+using UnityExplorer.UI.Panels;
 using UniverseLib.UI;
 using UniverseLib.UI.Models;
 
@@ -12,7 +13,7 @@ namespace UnityExplorer.UI.Widgets
         string lastGoName;
         string lastPath;
         bool lastParentState;
-        int lastSceneHandle;
+        string lastSceneId;
         string lastTag;
         int lastLayer;
         int lastFlags;
@@ -40,7 +41,16 @@ namespace UnityExplorer.UI.Widgets
             this.Owner = owner;
             Create();
         }
+        private static string GetSceneId(Scene scene)
+        {
+            if (!scene.IsValid())
+                return "invalid";
 
+            if (!string.IsNullOrEmpty(scene.path))
+                return scene.path;
+
+            return scene.name;
+        }
         public void UpdateGameObjectInfo(bool firstUpdate, bool force)
         {
             if (firstUpdate)
@@ -92,9 +102,9 @@ namespace UnityExplorer.UI.Widgets
                 IsStaticToggle.Set(Target.isStatic, false);
             }
 
-            if (force || Target.scene.handle != lastSceneHandle)
+            if (force || GetSceneId(Target.scene) != lastSceneId) //scene.handle no longer exists in unity 6, had to replace it with something else.
             {
-                lastSceneHandle = Target.scene.handle;
+                lastSceneId = GetSceneId(Target.scene);
                 SceneButton.ButtonText.text = Target.scene.IsValid() ? Target.scene.name : "None (Asset/Resource)";
             }
 


### PR DESCRIPTION
Fixes [this](https://github.com/originalnicodr/CinematicUnityExplorer/issues/122) issue.

Scene.GetNameInternal(int) no longer exists, and the new version is private. Created DoesDontDestroyOnLoadExist() method to replace it.  There's probably a better way of doing this without iterating through all scenes, but if it only runs once on init, it's probably not horrible.

Removed all references to scene.handle, as it doesn't exist in Unity 6. Mostly replaced them with scene.name.

Commented out LoadedScenes.Add in SceneHandler.Update() I don't know if that has any negative effects, but it seems to work in the limited testing I did.  Hopefully someone with more knowledge of the codebase can tell me if this is actually horrible.

"Tested" with Unity 6 game "Forever-Happy-Town demo" and Unity 2022 game "Mycopunk".  By tested I just mean it loads without errors and seems to display correctly.  I did not do any testing for any deeper issues.

