### PR TITLE
Fix inspecting non-atlas sprites

### DIFF
--- a/src/UI/Widgets/UnityObjects/Texture2DWidget.cs
+++ b/src/UI/Widgets/UnityObjects/Texture2DWidget.cs
@@ -33,7 +33,7 @@ namespace UnityExplorer.UI.Widgets
             }
             else if (target.TryCast<Sprite>() is Sprite sprite)
             {
-                if (sprite.packingMode == SpritePackingMode.Tight)
+                if (sprite.packed && sprite.packingMode == SpritePackingMode.Tight)
                     texture = sprite.texture;
                 else
                 {
@@ -43,7 +43,7 @@ namespace UnityExplorer.UI.Widgets
             }
             else if (target.TryCast<Image>() is Image image)
             {
-                if (image.sprite.packingMode == SpritePackingMode.Tight)
+                if (image.sprite.packed && image.sprite.packingMode == SpritePackingMode.Tight)
                     texture = image.sprite.texture;
                 else
                 {


### PR DESCRIPTION
For whatever reason, Unity *throws an exception* if you try to read the `packingMode` (or `packingRotation`) of a `Sprite` that isn't packed in an atlas. As a result, whenever you try to inspect such a sprite, it fails to properly open the object and puts the UI in a weird state:
<img width="2076" height="1379" alt="image" src="https://github.com/user-attachments/assets/72b3616e-d034-4a30-bb3b-7516c5fe3c66" />
